### PR TITLE
Add Local Time and its format pattern

### DIFF
--- a/src/main/java/com/microsoft/shinyay/ai/demo/service/ChatService.java
+++ b/src/main/java/com/microsoft/shinyay/ai/demo/service/ChatService.java
@@ -18,6 +18,8 @@ public class ChatService {
         // Azure OpenAI API へのリクエストを構築し、レスポンスを取得するロジックを実装
         String url = config.getEndpoint();
         // API リクエストの詳細は省略
-        return "Response from Azure OpenAI";
+        String response = "Response from Azure OpenAI";
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        return response + " (Received at: " + timestamp + ")";
     }
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `ChatService` class. The change adds a timestamp to the response from the Azure OpenAI API.

Enhancements to response formatting:

* [`src/main/java/com/microsoft/shinyay/ai/demo/service/ChatService.java`](diffhunk://#diff-4237022958d0c5133d417584e39c67fe8e35a6c1daa221303416ea25049c4248L21-R23): Modified the `getChatResponse` method to include a timestamp in the response string.