### PR TITLE
Add message history saving feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,20 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-azure-openai-spring-boot-starter</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/microsoft/shinyay/ai/demo/model/ChatMessage.java
+++ b/src/main/java/com/microsoft/shinyay/ai/demo/model/ChatMessage.java
@@ -1,13 +1,30 @@
 package com.microsoft.shinyay.ai.demo.model;
 
+import javax.persistence.*;
+
+@Entity
 public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
     private String message;
+
+    @Column(nullable = false)
+    private String response;
 
     public ChatMessage() {
     }
 
-    public ChatMessage(String message) {
+    public ChatMessage(String message, String response) {
         this.message = message;
+        this.response = response;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getMessage() {
@@ -16,5 +33,13 @@ public class ChatMessage {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
     }
 }

--- a/src/main/java/com/microsoft/shinyay/ai/demo/repository/ChatMessageRepository.java
+++ b/src/main/java/com/microsoft/shinyay/ai/demo/repository/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package com.microsoft.shinyay.ai.demo.repository;
+
+import com.microsoft.shinyay.ai.demo.model.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/microsoft/shinyay/ai/demo/service/ChatService.java
+++ b/src/main/java/com/microsoft/shinyay/ai/demo/service/ChatService.java
@@ -1,6 +1,8 @@
 package com.microsoft.shinyay.ai.demo.service;
 
 import com.microsoft.shinyay.ai.demo.config.AzureOpenAIConfig;
+import com.microsoft.shinyay.ai.demo.model.ChatMessage;
+import com.microsoft.shinyay.ai.demo.repository.ChatMessageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -14,10 +16,19 @@ public class ChatService {
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
     public String getChatResponse(String message) {
         // Azure OpenAI API へのリクエストを構築し、レスポンスを取得するロジックを実装
         String url = config.getEndpoint();
         // API リクエストの詳細は省略
-        return "Response from Azure OpenAI";
+        String response = "Response from Azure OpenAI";
+
+        // Save the message and response to the database
+        ChatMessage chatMessage = new ChatMessage(message, response);
+        chatMessageRepository.save(chatMessage);
+
+        return response;
     }
 }


### PR DESCRIPTION
Related to #5

Add functionality to save chat messages and their responses to the database.

* **Dependencies**: Add dependencies for Spring Data JPA, H2 database, and Lombok in `pom.xml`.
* **Database Configuration**: Add H2 database configuration properties in `src/main/resources/application.properties`.
* **Model**: Annotate `ChatMessage` class with `@Entity`, add fields for id, message, and response, and add necessary JPA annotations.
* **Repository**: Create `ChatMessageRepository` interface extending `JpaRepository<ChatMessage, Long>`.
* **Service**: Inject `ChatMessageRepository` in `ChatService` and update `getChatResponse` method to save the message and response to the database.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-spring-ai-chat-model/issues/5?shareId=75266557-7286-453f-9a4e-3c75d5796594).